### PR TITLE
Add navigation back and margins in favorites section

### DIFF
--- a/src/navigation/FavoritesNavigator.js
+++ b/src/navigation/FavoritesNavigator.js
@@ -1,12 +1,15 @@
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { Image, Text, View } from 'react-native';
+import { TouchableWithoutFeedback } from 'react-native-gesture-handler';
 import React from 'react';
+import { useNavigation } from '@react-navigation/native';
 import { backIcon } from '@/assets';
 import { NAVIGATION } from '@/constants';
 import { MY_LIST } from '@/constants/en';
 import { Favorites } from '@/screens/Favorites/Favorites';
 import { styles } from '@/screens/Favorites/Favorites.styles';
 import { blackColor } from '@/constants/colors';
+import { TABS } from '@/constants/navigation';
 
 const Stack = createNativeStackNavigator();
 
@@ -28,14 +31,22 @@ export function FavoritesNavigator() {
 }
 
 function FavoritesHeader() {
+  const navigation = useNavigation();
+
   return (
     <View style={styles.container}>
-      <View style={styles.containerIcon}>
-        <Image
-          style={styles.iconHeader}
-          source={backIcon}
+      <View>
+        <TouchableWithoutFeedback
+          accessibilityRole="button"
+          onPress={() => navigation.jumpTo(TABS.home)}
           accessibilityIgnoresInvertColors={true}
-        />
+        >
+          <Image
+            style={styles.iconHeader}
+            source={backIcon}
+            accessibilityIgnoresInvertColors={true}
+          />
+        </TouchableWithoutFeedback>
       </View>
       <View style={styles.containerText}>
         <Text style={styles.textBack}>{MY_LIST}</Text>

--- a/src/screens/Favorites/Favorites.styles.js
+++ b/src/screens/Favorites/Favorites.styles.js
@@ -16,7 +16,7 @@ export const styles = StyleSheet.create({
 
   avatar: {
     height: 180,
-    width: 125,
+    width: 115,
   },
 
   image: {
@@ -25,7 +25,7 @@ export const styles = StyleSheet.create({
   },
 
   flatList: {
-    marginTop: 40,
+    padding: 20,
   },
 
   containerView: {


### PR DESCRIPTION
#### 📄&nbsp; Description:

This pr contains back action in favorites section and set the margins.

---

#### 📌&nbsp; Notes:


---

#### ✔️&nbsp; Performed Tasks:

- Set margins
- Back action

---

#### ⏯&nbsp; Demo:

Android:

<img width="477" alt="Captura de pantalla 2023-01-16 a la(s) 15 00 45" src="https://user-images.githubusercontent.com/45951048/212741377-3e15b812-427f-4d77-a82b-bdf809b784a4.png">

IOS:

<img width="446" alt="Captura de pantalla 2023-01-16 a la(s) 15 02 09" src="https://user-images.githubusercontent.com/45951048/212741679-52c113b2-a5e1-48db-89b2-70717de874bf.png">

![back](https://user-images.githubusercontent.com/45951048/212741766-2c923e61-cfc6-47bc-b937-111ea6fa0f4b.gif)



